### PR TITLE
Add config LeadReader function and fix timings calculation

### DIFF
--- a/common/http/client_test.go
+++ b/common/http/client_test.go
@@ -51,6 +51,8 @@ func (t *DummyTracer) Timings() Timings {
 	}
 }
 
+func (t *DummyTracer) Done() {}
+
 func TestTimedClient_Do(t *testing.T) {
 	type fields struct {
 		code   int


### PR DESCRIPTION
## Description

Add a function to load a config from an `io.Reader` in addition to the existing one for loading it from a file path.

The content transfer timing wasn't properly calculated

### Type of change

- New feature (non-breaking change which adds functionality)
- Bug Fix

### Checklist:

- [x] I have performed a self-review of my own code
- [x] Go code is formatted with `gofmt`
- [x] I have made corresponding changes to the docs in `/docs` and in the `README`
- [x] I have added tests (unit and/or end-to-end) that prove my fix is effective or that my feature works
- [x] Any dependent changes have been merged and published (in downstream modules)
