### PR TITLE
Step executor interface made public

### DIFF
--- a/common/step/executor.go
+++ b/common/step/executor.go
@@ -8,8 +8,8 @@ import (
 	"github.com/getapid/apid-cli/common/log"
 )
 
-type executor interface {
-	do(Request) (*http.Response, error)
+type Executor interface {
+	Do(Request) (*http.Response, error)
 }
 
 type httpExecutor struct {
@@ -17,11 +17,11 @@ type httpExecutor struct {
 }
 
 // NewHTTPExecutor instantiates a new http executor
-func NewHTTPExecutor(client http.Client) executor {
+func NewHTTPExecutor(client http.Client) Executor {
 	return &httpExecutor{client: client}
 }
 
-func (e *httpExecutor) do(request Request) (*http.Response, error) {
+func (e *httpExecutor) Do(request Request) (*http.Response, error) {
 	req, err := http.NewRequest(request.Type, request.Endpoint, strings.NewReader(request.Body))
 	if err != nil {
 		return nil, err

--- a/common/step/runner.go
+++ b/common/step/runner.go
@@ -14,7 +14,7 @@ type Runner interface {
 }
 
 type runner struct {
-	executor     executor
+	executor     Executor
 	validator    validator
 	interpolator interpolator
 	extractor    extractor
@@ -41,7 +41,7 @@ func (r *Result) AddErr(key string, err error) {
 
 // NewRunner instantiates a new HTTPRunner
 func NewRunner(
-	executor executor,
+	executor Executor,
 	validator validator,
 	interpolator interpolator,
 	extractor extractor) Runner {
@@ -58,7 +58,7 @@ func (c *runner) Run(step Step, vars variables.Variables) (Result, error) {
 		result.AddErr("prepare", err)
 		return result, err
 	}
-	response, err := c.executor.do(result.Step.Request)
+	response, err := c.executor.Do(result.Step.Request)
 	if err != nil {
 		result.AddErr("execute", err)
 		return result, err


### PR DESCRIPTION
## Description

This change exposes the Step Executor interface as public including it's methods.

### Type of change

- New feature (non-breaking change which adds functionality)

### Checklist:

- [ X ] I have performed a self-review of my own code
- [ X ] Go code is formatted with `gofmt`
- [ X ] I have made corresponding changes to the docs in `/docs` and in the `README`
- [ X ] I have added tests (unit and/or end-to-end) that prove my fix is effective or that my feature works
- [ X ] Any dependent changes have been merged and published (in downstream modules)
