### PR TITLE
Removed http.Response native dependency

### DIFF
--- a/common/http/client_test.go
+++ b/common/http/client_test.go
@@ -112,8 +112,8 @@ func TestTimedClient_Do(t *testing.T) {
 			if got.StatusCode != tt.want.code {
 				t.Errorf("TimedClient.Do() = %v, want %v", got.StatusCode, tt.want.code)
 			}
-			if !bytes.Equal(got.ReadBody, tt.want.body) {
-				t.Errorf("TimedClient.Do() = %v, want %v", got.ReadBody, tt.want.body)
+			if !bytes.Equal(got.Body, tt.want.body) {
+				t.Errorf("TimedClient.Do() = %v, want %v", got.Body, tt.want.body)
 			}
 			if got.Timings.ContentTransfer != d {
 				t.Errorf("TimedClient.Do() = %v, want %v", got.Timings.ContentTransfer, d)

--- a/common/step/executor.go
+++ b/common/step/executor.go
@@ -52,7 +52,7 @@ func (e *httpExecutor) Do(request Request) (*http.Response, error) {
 	log.L.Debugw("received response",
 		"endpoint", req.URL,
 		"method", req.Method,
-		"body", string(resp.ReadBody),
+		"body", string(resp.Body),
 		"headers", resp.Header,
 	)
 

--- a/common/step/extractor.go
+++ b/common/step/extractor.go
@@ -31,7 +31,7 @@ func NewBodyExtractor() extractor {
 func (e *bodyExtractor) extract(response *http.Response, export Export) Exported {
 	exported := make(Exported, len(export))
 	var jsonBody interface{}
-	err := json.Unmarshal(response.ReadBody, &jsonBody)
+	err := json.Unmarshal(response.Body, &jsonBody)
 	if err != nil {
 		return exported
 	}

--- a/common/step/validate.go
+++ b/common/step/validate.go
@@ -34,7 +34,6 @@ func NewHTTPValidator() validator {
 }
 
 func (v httpValidator) validate(exp ExpectedResponse, actual *http.Response) (result ValidationResult) {
-	defer actual.Body.Close()
 	errMsgs := make(map[string]string)
 	appendErr := func(errors map[string]string, key string, err error) {
 		if err != nil {
@@ -44,7 +43,7 @@ func (v httpValidator) validate(exp ExpectedResponse, actual *http.Response) (re
 
 	appendErr(errMsgs, "code", v.validateCode(exp.Code, actual.StatusCode))
 	appendErr(errMsgs, "headers", v.validateHeaders(exp.Headers, actual.Header))
-	appendErr(errMsgs, "body", v.validateBody(exp.Body, actual.ReadBody))
+	appendErr(errMsgs, "body", v.validateBody(exp.Body, actual.Body))
 
 	result.Errors = errMsgs
 	return

--- a/common/step/validate_test.go
+++ b/common/step/validate_test.go
@@ -2,7 +2,6 @@ package step
 
 import (
 	"io"
-	stdhttp "net/http"
 	"testing"
 
 	"github.com/getapid/apid-cli/common/http"
@@ -36,10 +35,7 @@ func (s *ValidatorSuite) TestValidate() {
 					Code: pint(200),
 				},
 				actual: &http.Response{
-					Response: &stdhttp.Response{
-						Body:       &stringReadCloser{},
-						StatusCode: 200,
-					},
+					StatusCode: 200,
 				},
 			},
 			expResult: correctResult,
@@ -51,10 +47,7 @@ func (s *ValidatorSuite) TestValidate() {
 					Code: pint(201),
 				},
 				actual: &http.Response{
-					Response: &stdhttp.Response{
-						Body:       &stringReadCloser{},
-						StatusCode: 200,
-					},
+					StatusCode: 200,
 				},
 			},
 			expResult: incorrectStatusResult,
@@ -68,11 +61,8 @@ func (s *ValidatorSuite) TestValidate() {
 					},
 				},
 				actual: &http.Response{
-					Response: &stdhttp.Response{
-						Body: &stringReadCloser{},
-						Header: map[string][]string{
-							"HEADER1": {"value1"},
-						},
+					Header: map[string][]string{
+						"HEADER1": {"value1"},
 					},
 				},
 			},
@@ -87,11 +77,8 @@ func (s *ValidatorSuite) TestValidate() {
 					},
 				},
 				actual: &http.Response{
-					Response: &stdhttp.Response{
-						Body: &stringReadCloser{},
-						Header: map[string][]string{
-							"HEADER1": {"value2"},
-						},
+					Header: map[string][]string{
+						"HEADER1": {"value2"},
 					},
 				},
 			},
@@ -108,10 +95,7 @@ func (s *ValidatorSuite) TestValidate() {
 					},
 				},
 				actual: &http.Response{
-					Response: &stdhttp.Response{
-						Body: &stringReadCloser{},
-					},
-					ReadBody: []byte(`{"field1":"exact value"}`),
+					Body: []byte(`{"field1":"exact value"}`),
 				},
 			},
 			expResult: correctResult,
@@ -127,10 +111,7 @@ func (s *ValidatorSuite) TestValidate() {
 					},
 				},
 				actual: &http.Response{
-					Response: &stdhttp.Response{
-						Body: &stringReadCloser{},
-					},
-					ReadBody: []byte(`{"field1":1}`),
+					Body: []byte(`{"field1":1}`),
 				},
 			},
 			expResult: correctResult,
@@ -146,10 +127,7 @@ func (s *ValidatorSuite) TestValidate() {
 					},
 				},
 				actual: &http.Response{
-					Response: &stdhttp.Response{
-						Body: &stringReadCloser{},
-					},
-					ReadBody: []byte(`hi, what's up mate'`),
+					Body: []byte(`hi, what's up mate'`),
 				},
 			},
 			expResult: correctResult,
@@ -165,10 +143,7 @@ func (s *ValidatorSuite) TestValidate() {
 					},
 				},
 				actual: &http.Response{
-					Response: &stdhttp.Response{
-						Body: &stringReadCloser{},
-					},
-					ReadBody: []byte(`{"field1":"value matters"}`),
+					Body: []byte(`{"field1":"value matters"}`),
 				},
 			},
 			expResult: incorrectBodyResult,
@@ -184,10 +159,7 @@ func (s *ValidatorSuite) TestValidate() {
 					},
 				},
 				actual: &http.Response{
-					Response: &stdhttp.Response{
-						Body: &stringReadCloser{},
-					},
-					ReadBody: []byte(`{"field1":{"b":1}}`),
+					Body: []byte(`{"field1":{"b":1}}`),
 				},
 			},
 			expResult: incorrectBodyResult,
@@ -203,10 +175,7 @@ func (s *ValidatorSuite) TestValidate() {
 					},
 				},
 				actual: &http.Response{
-					Response: &stdhttp.Response{
-						Body: &stringReadCloser{},
-					},
-					ReadBody: []byte(`[{"field1":{"a":1}}]`),
+					Body: []byte(`[{"field1":{"a":1}}]`),
 				},
 			},
 			expResult: correctResult,
@@ -222,10 +191,7 @@ func (s *ValidatorSuite) TestValidate() {
 					},
 				},
 				actual: &http.Response{
-					Response: &stdhttp.Response{
-						Body: &stringReadCloser{},
-					},
-					ReadBody: []byte(`[{"field1":{"a":1}},{"field1":{"b":1}}]`),
+					Body: []byte(`[{"field1":{"a":1}},{"field1":{"b":1}}]`),
 				},
 			},
 			expResult: incorrectBodyResult,


### PR DESCRIPTION
## Description

Remove the dependency on net/http for responses. Modified the http client response type to include most common fields of a response - body, headers and status code. On top of those also attach the timings of the request.

### Type of change

- New feature (non-breaking change which adds functionality)

### Checklist:

- [ X ] I have performed a self-review of my own code
- [ X ] Go code is formatted with `gofmt`
- [ X ] I have made corresponding changes to the docs in `/docs` and in the `README`
- [ X ] I have added tests (unit and/or end-to-end) that prove my fix is effective or that my feature works
- [ X ] Any dependent changes have been merged and published (in downstream modules)
