### PR TITLE
Correct form of a key in the reference

### DIFF
--- a/docs/reference.md
+++ b/docs/reference.md
@@ -214,7 +214,7 @@ Body provides a bit more flexibility on what body to expect in this response.
 | is       | string | yes      |         | What content of the body (or selector content) to expect                                                                                                                                                                              |
 | selector | string | no       | -       | A selector to get part of the body. The underlying implementation is using `gjson`, reference of syntax can be found [here](https://github.com/tidwall/gjson/blob/master/SYNTAX.md)                                                   |
 | subset   | bool   | no       | no      | If the `is` block is a subset of the body (or selector content). See [examples](https://github.com/getapid/apid-cli/tree/master/testapi/tests).                                                                                       |
-| keysOnly | bool   | no       | no      | If values should be disregarded when checking for equality. All types of values except objects are ignored. Objects will still be recursively checked. See [examples](https://github.com/getapid/apid-cli/tree/master/testapi/tests). |
+| keys_only | bool   | no       | no      | If values should be disregarded when checking for equality. All types of values except objects are ignored. Objects will still be recursively checked. See [examples](https://github.com/getapid/apid-cli/tree/master/testapi/tests). |
 
 ```yaml
 expect:
@@ -239,7 +239,7 @@ expect:
         }
 
     - selector: name
-      keysOnly: true
+      keys_only: true
       is: |
         {
           "first": "Something, but not Tom", 
@@ -248,7 +248,7 @@ expect:
 
     - selector: name
       subset: true
-      keysOnly: true
+      keys_only: true
       is: |
         {
           "first": "Something, but not Tom"


### PR DESCRIPTION
## Description

I was having trouble getting `keysOnly` to work, after staring at the examples for awhile I noticed that they use `keys_only` — so I looked at the source and found that, yes, the YAML tag for this field is `keys_only`. So I figured we should fix the reference.

### Type of change

- Bug fix (non-breaking change which fixes an issue)

### Checklist:

- [X] I have performed a self-review of my own code
- [ ] ~~Go code is formatted with `gofmt`~~ (N/A)
- [ ] ~~I have made corresponding changes to the docs in `/docs` and in the `README`~~ (N/A)
- [ ] ~~I have added tests (unit and/or end-to-end) that prove my fix is effective or that my feature works~~ (N/A)
- [ ] ~~Any dependent changes have been merged and published (in downstream modules)~~ (N/A)
