### PR TITLE
Fix goreleaser and add arm64

### DIFF
--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -5,25 +5,25 @@ before:
     - go mod tidy
 
 builds:
-- main: svc/cli/main.go
-  env:
-    - CGO_ENABLED=0
-  binary: apid
-  ldflags:
-    - '-w'
-    - '-s'
-    - '-X github.com/getapid/apid-cli/svc/cli/cmd.version={{ .Version }}'
-  goos:
-    - linux
-    - openbsd
-    - solaris
-    - freebsd
-    - darwin
-    - windows
-  goarch: [386, amd64, arm]
+  - main: svc/cli/main.go
+    env:
+      - CGO_ENABLED=0
+    binary: apid
+    ldflags:
+      - "-w"
+      - "-s"
+      - "-X github.com/getapid/apid-cli/svc/cli/cmd.version={{ .Version }}"
+    goos:
+      - linux
+      - openbsd
+      - solaris
+      - freebsd
+      - darwin
+      - windows
+    goarch: [386, amd64, arm, arm64]
 
 checksum:
-  name_template: 'checksums.txt'
+  name_template: "checksums.txt"
 
 snapshot:
   name_template: "{{ .ShortCommit }}"
@@ -41,7 +41,7 @@ archives:
 dockers:
   - goos: linux
     goarch: amd64
-    binaries:
+    ids:
       - apid
 
     image_templates:

--- a/svc/cli/dockerfile
+++ b/svc/cli/dockerfile
@@ -1,3 +1,4 @@
-FROM scratch
-COPY apid /usr/local/bin/apid
+FROM alpine:latest
 ENTRYPOINT ["/usr/local/bin/apid"]
+RUN apk --no-cache add ca-certificates
+COPY apid /usr/local/bin/apid


### PR DESCRIPTION
## Description

Move docker image from scratch to alpine and add cacerts.
Adds arm64 as build target to support m1 macs

### Type of change

- Bug fix (non-breaking change which fixes an issue)

### Checklist:

- [ x ] I have performed a self-review of my own code
- [ x ] Go code is formatted with `gofmt`
- [ x ] I have made corresponding changes to the docs in `/docs` and in the `README`
- [ x ] I have added tests (unit and/or end-to-end) that prove my fix is effective or that my feature works
- [ x ] Any dependent changes have been merged and published (in downstream modules)
