### PR TITLE
Fix jobs buffer size

### DIFF
--- a/testapi/tests/public/lots.yaml
+++ b/testapi/tests/public/lots.yaml
@@ -144,38 +144,38 @@ transactions:
         expect:
           code: 200
 
-  # - id: simple-request16
-  #   steps:
-  #     - id: get
-  #       request:
-  #         method: "GET"
-  #         endpoint: "{{ var.url }}/get"
-  #       expect:
-  #         code: 200
+  - id: simple-request16
+    steps:
+      - id: get
+        request:
+          method: "GET"
+          endpoint: "{{ var.url }}/get"
+        expect:
+          code: 200
 
-  # - id: simple-request17
-  #   steps:
-  #     - id: get
-  #       request:
-  #         method: "GET"
-  #         endpoint: "{{ var.url }}/get"
-  #       expect:
-  #         code: 200
+  - id: simple-request17
+    steps:
+      - id: get
+        request:
+          method: "GET"
+          endpoint: "{{ var.url }}/get"
+        expect:
+          code: 200
 
-  # - id: simple-request18
-  #   steps:
-  #     - id: get
-  #       request:
-  #         method: "GET"
-  #         endpoint: "{{ var.url }}/get"
-  #       expect:
-  #         code: 200
+  - id: simple-request18
+    steps:
+      - id: get
+        request:
+          method: "GET"
+          endpoint: "{{ var.url }}/get"
+        expect:
+          code: 200
 
-  # - id: simple-request19
-  #   steps:
-  #     - id: get
-  #       request:
-  #         method: "GET"
-  #         endpoint: "{{ var.url }}/get"
-  #       expect:
-  #         code: 200
+  - id: simple-request19
+    steps:
+      - id: get
+        request:
+          method: "GET"
+          endpoint: "{{ var.url }}/get"
+        expect:
+          code: 200

--- a/testapi/tests/public/lots.yaml
+++ b/testapi/tests/public/lots.yaml
@@ -1,0 +1,181 @@
+variables:
+  url: "https://httpbin.org"
+transactions:
+  - id: simple-request
+    steps:
+      - id: get
+        request:
+          method: "GET"
+          endpoint: "{{ var.url }}/get"
+        expect:
+          code: 200
+  - id: simple-request1
+    steps:
+      - id: get
+        request:
+          method: "GET"
+          endpoint: "{{ var.url }}/get"
+        expect:
+          code: 200
+
+  - id: simple-request2
+    steps:
+      - id: get
+        request:
+          method: "GET"
+          endpoint: "{{ var.url }}/get"
+        expect:
+          code: 200
+
+  - id: simple-request3
+    steps:
+      - id: get
+        request:
+          method: "GET"
+          endpoint: "{{ var.url }}/get"
+        expect:
+          code: 200
+
+  - id: simple-request4
+    steps:
+      - id: get
+        request:
+          method: "GET"
+          endpoint: "{{ var.url }}/get"
+        expect:
+          code: 200
+
+  - id: simple-request5
+    steps:
+      - id: get
+        request:
+          method: "GET"
+          endpoint: "{{ var.url }}/get"
+        expect:
+          code: 200
+
+  - id: simple-request6
+    steps:
+      - id: get
+        request:
+          method: "GET"
+          endpoint: "{{ var.url }}/get"
+        expect:
+          code: 200
+
+  - id: simple-request7
+    steps:
+      - id: get
+        request:
+          method: "GET"
+          endpoint: "{{ var.url }}/get"
+        expect:
+          code: 200
+
+  - id: simple-request8
+    steps:
+      - id: get
+        request:
+          method: "GET"
+          endpoint: "{{ var.url }}/get"
+        expect:
+          code: 200
+
+  - id: simple-request9
+    steps:
+      - id: get
+        request:
+          method: "GET"
+          endpoint: "{{ var.url }}/get"
+        expect:
+          code: 200
+
+  - id: simple-request0
+    steps:
+      - id: get
+        request:
+          method: "GET"
+          endpoint: "{{ var.url }}/get"
+        expect:
+          code: 200
+
+  - id: simple-request11
+    steps:
+      - id: get
+        request:
+          method: "GET"
+          endpoint: "{{ var.url }}/get"
+        expect:
+          code: 200
+
+  - id: simple-request12
+    steps:
+      - id: get
+        request:
+          method: "GET"
+          endpoint: "{{ var.url }}/get"
+        expect:
+          code: 200
+
+  - id: simple-request13
+    steps:
+      - id: get
+        request:
+          method: "GET"
+          endpoint: "{{ var.url }}/get"
+        expect:
+          code: 200
+
+  - id: simple-request14
+    steps:
+      - id: get
+        request:
+          method: "GET"
+          endpoint: "{{ var.url }}/get"
+        expect:
+          code: 200
+
+  - id: simple-request15
+    steps:
+      - id: get
+        request:
+          method: "GET"
+          endpoint: "{{ var.url }}/get"
+        expect:
+          code: 200
+
+  # - id: simple-request16
+  #   steps:
+  #     - id: get
+  #       request:
+  #         method: "GET"
+  #         endpoint: "{{ var.url }}/get"
+  #       expect:
+  #         code: 200
+
+  # - id: simple-request17
+  #   steps:
+  #     - id: get
+  #       request:
+  #         method: "GET"
+  #         endpoint: "{{ var.url }}/get"
+  #       expect:
+  #         code: 200
+
+  # - id: simple-request18
+  #   steps:
+  #     - id: get
+  #       request:
+  #         method: "GET"
+  #         endpoint: "{{ var.url }}/get"
+  #       expect:
+  #         code: 200
+
+  # - id: simple-request19
+  #   steps:
+  #     - id: get
+  #       request:
+  #         method: "GET"
+  #         endpoint: "{{ var.url }}/get"
+  #       expect:
+  #         code: 200


### PR DESCRIPTION
## Description

The jobs and result buffers were deadlocking when there are more than 15 transactions, thus hanging the execution. This change resolves this by buffering the jobs in a list and pushing them to the channel in a coroutine so the result writer can start consuming the ready results. 

### Type of change

- Bug fix (non-breaking change which fixes an issue)

### Checklist:

- [ x ] I have performed a self-review of my own code
- [ x ] Go code is formatted with `gofmt`
- [ x ] I have made corresponding changes to the docs in `/docs` and in the `README`
- [ x ] I have added tests (unit and/or end-to-end) that prove my fix is effective or that my feature works
- [ x ] Any dependent changes have been merged and published (in downstream modules)
