### PR TITLE
Expose parallelism flag

### DIFF
--- a/common/transaction/runner.go
+++ b/common/transaction/runner.go
@@ -2,6 +2,7 @@ package transaction
 
 import (
 	"fmt"
+	"os"
 
 	"github.com/getapid/apid-cli/common/result"
 	"github.com/getapid/apid-cli/common/step"
@@ -31,14 +32,20 @@ type res struct {
 }
 
 type TransactionRunner struct {
-	stepRunner step.Runner
-	writer     result.Writer
+	stepRunner  step.Runner
+	writer      result.Writer
+	parallelism int
 }
 
-func NewTransactionRunner(stepRunner step.Runner, writer result.Writer) Runner {
+func NewTransactionRunner(stepRunner step.Runner, writer result.Writer, parallelism int) Runner {
+	if parallelism < 1 {
+		fmt.Printf("parallelism level is negative or zero ( %d ), exiting.\n", parallelism)
+		os.Exit(1)
+	}
 	return &TransactionRunner{
-		stepRunner: stepRunner,
-		writer:     writer,
+		stepRunner:  stepRunner,
+		writer:      writer,
+		parallelism: parallelism,
 	}
 }
 
@@ -65,7 +72,7 @@ func (r *TransactionRunner) Run(transactions []Transaction, vars variables.Varia
 	jobsChan := make(chan job)
 	resultsChan := make(chan res)
 
-	workers := 5
+	workers := r.parallelism
 	if workers > len(jobs) {
 		workers = len(jobs)
 	}

--- a/common/transaction/runner_test.go
+++ b/common/transaction/runner_test.go
@@ -280,8 +280,9 @@ func (s *RunnerSuite) TestTransactionRunner_Run() {
 		mockedCalls = append(mockedCalls, writer.EXPECT().Close())
 
 		r := &TransactionRunner{
-			stepRunner: stepRunner,
-			writer:     writer,
+			stepRunner:  stepRunner,
+			writer:      writer,
+			parallelism: 10,
 		}
 		ok := r.Run(tt.args.transactions, tt.args.vars)
 		s.Equal(tt.ok, ok, tt.name)
@@ -325,8 +326,9 @@ func (s *RunnerSuite) TestTransactionRunner_RunWithMatrix() {
 	mockWriter.EXPECT().Close()
 
 	r := &TransactionRunner{
-		stepRunner: mockStepRunner,
-		writer:     mockWriter,
+		stepRunner:  mockStepRunner,
+		writer:      mockWriter,
+		parallelism: 10,
 	}
 	ok := r.Run([]Transaction{transaction}, rootVars)
 	s.True(ok)

--- a/docs/cli/check.md
+++ b/docs/cli/check.md
@@ -8,10 +8,11 @@ Check takes all the transactions that you have specified in the yaml. The steps 
 
 ## Flags
 
-| Flag      | Short | Required | Default     | Description                                                                       |
-| :-------- | :---- | :------- | :---------- | :-------------------------------------------------------------------------------- |
-| --config  | -c    | no       | ./apid.yaml | The config file. If a folder is provided will recursively load all `*.yaml` files |
-| --timings | -t    | no       | false       | Display the request timings, like DNS lookup, TCP connect, TLS handshake, etc     |
+| Flag          | Short | Required | Default     | Description                                                                       |
+| :------------ | :---- | :------- | :---------- | :-------------------------------------------------------------------------------- |
+| --config      | -c    | no       | ./apid.yaml | The config file. If a folder is provided will recursively load all `*.yaml` files |
+| --timings     | -t    | no       | false       | Display the request timings, like DNS lookup, TCP connect, TLS handshake, etc     |
+| --parallelism | -p    | no       | 10          | Number of transactions to be run in parallel                                      |
 
 # Examples
 

--- a/docs/cli/cloud/check.md
+++ b/docs/cli/cloud/check.md
@@ -8,12 +8,13 @@ Check takes all the transactions that you have specified in the yaml. The steps 
 
 ## Flags
 
-| Flag      | Short | Required | Default     | Description                                                                                                                   |
-| :-------- | :---- | :------- | :---------- | :---------------------------------------------------------------------------------------------------------------------------- |
-| --key     | -k    | yes      |             | [Your API key](../cloud/README.md), this can also be injected via the `APID_KEY` environment variable. Flag takes precedence. |
-| --region  | -r    | no       | washington  | The location to run the tests from, a list or regions can be found [here](../cloud/README.md)                                 |
-| --config  | -c    | no       | ./apid.yaml | The config file. If a folder is provided will recursively load all `*.yaml` files                                             |
-| --timings | -t    | no       | false       | Display the request timings, like DNS lookup, TCP connect, TLS handshake, etc                                                 |
+| Flag          | Short | Required | Default     | Description                                                                                                                   |
+| :------------ | :---- | :------- | :---------- | :---------------------------------------------------------------------------------------------------------------------------- |
+| --key         | -k    | yes      |             | [Your API key](../cloud/README.md), this can also be injected via the `APID_KEY` environment variable. Flag takes precedence. |
+| --region      | -r    | no       | washington  | The location to run the tests from, a list or regions can be found [here](../cloud/README.md)                                 |
+| --config      | -c    | no       | ./apid.yaml | The config file. If a folder is provided will recursively load all `*.yaml` files                                             |
+| --timings     | -t    | no       | false       | Display the request timings, like DNS lookup, TCP connect, TLS handshake, etc                                                 |
+| --parallelism | -p    | no       | 10          | Number of transactions to be run in parallel                                                                                  |
 
 # Examples
 

--- a/svc/cli/cmd/check.go
+++ b/svc/cli/cmd/check.go
@@ -17,6 +17,7 @@ import (
 var (
 	configFilepath string
 	showTimings    bool
+	parallelism    int
 )
 
 var checkCmd = &cobra.Command{
@@ -38,6 +39,7 @@ func init() {
 	rootCmd.AddCommand(checkCmd)
 	checkCmd.Flags().StringVarP(&configFilepath, "config", "c", "./apid.yaml", "file with config to run")
 	checkCmd.Flags().BoolVarP(&showTimings, "timings", "t", false, "output the durations of request steps")
+	checkCmd.Flags().IntVarP(&parallelism, "parallelism", "p", 10, "number of concurrent transaction executions")
 }
 
 func checkRun(cmd *cobra.Command, args []string) error {
@@ -62,7 +64,7 @@ func checkRun(cmd *cobra.Command, args []string) error {
 	stepExtractor := step.NewBodyExtractor()
 	stepChecker := step.NewRunner(stepExecutor, stepValidator, stepInterpolator, stepExtractor)
 
-	transactionRunner := transaction.NewTransactionRunner(stepChecker, writer)
+	transactionRunner := transaction.NewTransactionRunner(stepChecker, writer, parallelism)
 
 	vars := c.Variables.Merge(variables.New(variables.WithEnv()))
 	ok := transactionRunner.Run(c.Transactions, vars)

--- a/svc/cli/cmd/cloud/check.go
+++ b/svc/cli/cmd/cloud/check.go
@@ -17,8 +17,9 @@ import (
 )
 
 var (
-	region      = ""
-	showTimings = false
+	region      string
+	showTimings bool
+	parallelism int
 )
 
 var checkCmd = &cobra.Command{
@@ -42,6 +43,7 @@ func init() {
 	RootCommand.AddCommand(checkCmd)
 	checkCmd.Flags().StringVarP(&configFilepath, "config", "c", "./apid.yaml", "file with config to run")
 	checkCmd.Flags().BoolVarP(&showTimings, "timings", "t", false, "output the durations of requests")
+	checkCmd.Flags().IntVarP(&parallelism, "parallelism", "p", 10, "number of concurrent transaction executions")
 	checkCmd.Flags().StringVarP(&region, "region", "r", "washington", "location to run the tests from")
 }
 
@@ -69,7 +71,7 @@ func remoteCheck(cmd *cobra.Command, args []string) error {
 	stepExtractor := step.NewBodyExtractor()
 	stepChecker := step.NewRunner(stepExecutor, stepValidator, stepInterpolator, stepExtractor)
 
-	transactionRunner := transaction.NewTransactionRunner(stepChecker, writer)
+	transactionRunner := transaction.NewTransactionRunner(stepChecker, writer, parallelism)
 
 	vars := c.Variables.Merge(variables.New(variables.WithEnv()))
 	ok := transactionRunner.Run(c.Transactions, vars)


### PR DESCRIPTION
## Description

Expose a flag on the CLI that controls how many transactions will be run in parallel.

### Type of change

- New feature (non-breaking change which adds functionality)

### Checklist:

- [ x ] I have performed a self-review of my own code
- [ x ] Go code is formatted with `gofmt`
- [ x ] I have made corresponding changes to the docs in `/docs` and in the `README`
- [ x ] I have added tests (unit and/or end-to-end) that prove my fix is effective or that my feature works
- [ x ] Any dependent changes have been merged and published (in downstream modules)
